### PR TITLE
fix help menu bug, restructure ui folder a bit

### DIFF
--- a/src/aws_stuff_doer/uilib/__init__.py
+++ b/src/aws_stuff_doer/uilib/__init__.py
@@ -1,3 +1,3 @@
 """The __init__.py filr for the ui module."""
 
-from .uilib import TerminalUi  # type: ignore
+from .uilib import AwsStuffDoer   # type: ignore

--- a/src/aws_stuff_doer/uilib/screens/__init__.py
+++ b/src/aws_stuff_doer/uilib/screens/__init__.py
@@ -1,0 +1,2 @@
+from .help_screen.HelpScreen import HelpScreen  # type: ignore
+from .main_screen.MainScreen import MainScreen  # type: ignore

--- a/src/aws_stuff_doer/uilib/screens/help_screen/HelpScreen.py
+++ b/src/aws_stuff_doer/uilib/screens/help_screen/HelpScreen.py
@@ -6,13 +6,13 @@ HELP_TEXT =  """
                            Help Menu
     ASD: An AWS Utility to help manage your projects and sso sessions.
 
-    Keybindings:
+    Key Bindings:
 
-        d: Toggle dark mode
         q: Quit
+        d: Toggle dark mode
+        m: Show main screen
         h: Show help
 
-    Press escape to exit.
     """
 
 class HelpScreen(Screen): # type: ignore

--- a/src/aws_stuff_doer/uilib/screens/help_screen/HelpScreen.py
+++ b/src/aws_stuff_doer/uilib/screens/help_screen/HelpScreen.py
@@ -1,0 +1,25 @@
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Header, Footer, Static
+
+HELP_TEXT =  """
+                           Help Menu
+    ASD: An AWS Utility to help manage your projects and sso sessions.
+
+    Keybindings:
+
+        d: Toggle dark mode
+        q: Quit
+        h: Show help
+
+    Press escape to exit.
+    """
+
+class HelpScreen(Screen): # type: ignore
+    """A simple help screen."""
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(HELP_TEXT)
+        yield Footer()
+

--- a/src/aws_stuff_doer/uilib/screens/main_screen/MainScreen.py
+++ b/src/aws_stuff_doer/uilib/screens/main_screen/MainScreen.py
@@ -1,0 +1,12 @@
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Header, Footer, Placeholder
+
+
+class MainScreen(Screen): # type: ignore
+    """A simple home screen."""
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Placeholder("Main Screen")
+        yield Footer()
+

--- a/src/aws_stuff_doer/uilib/uilib.py
+++ b/src/aws_stuff_doer/uilib/uilib.py
@@ -1,33 +1,24 @@
-from textual.app import App, ComposeResult
-from textual.events import Show
-from textual.widgets import Header, Footer
+from textual.app import App
+from aws_stuff_doer.uilib.screens import MainScreen, HelpScreen
 
+class AwsStuffDoer(App): # type: ignore
+    """beginnings of aws_stuff_doer terminal ui..."""
 
-class TerminalUi(App):
-    """A Textual app to manage stopwatches."""
+    MODES = { # type: ignore
+        "default": "main",
+        "help": "help",
+    }
 
+    SCREENS = {"main": MainScreen, "help": HelpScreen}
     TITLE = "ASD"
     SUB_TITLE = " An AWS Utility to help manage your projects and sso sessions."
+
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("d", "toggle_dark", "Toggle dark mode"),
-        ("?", "show_help", "Show help"),
+        ("m", "switch_mode('default')", "Main"),
+        ("h", "switch_mode('help')", "Help"),
     ]
-    help = """
-    ASD: An AWS Utility to help manage your projects and sso sessions.
-
-    Keybindings:
-
-        d: Toggle dark mode
-        q: Quit
-        ?: Show help
-
-    """
-
-    def compose(self) -> ComposeResult:
-        """Create child widgets for the app."""
-        yield Header()
-        yield Footer()
 
     def action_toggle_dark(self) -> None:
         """An action to toggle dark mode."""
@@ -38,7 +29,9 @@ class TerminalUi(App):
             self.dark = True
             self.refresh()
 
+    def on_mount(self) -> None:
+        self.switch_mode("default")
 
 if __name__ == "__main__":
-    app = TerminalUi()
+    app = AwsStuffDoer()
     app.run()

--- a/src/aws_stuff_doer/uilib/uilib.py
+++ b/src/aws_stuff_doer/uilib/uilib.py
@@ -1,10 +1,11 @@
 from textual.app import App
 from aws_stuff_doer.uilib.screens import MainScreen, HelpScreen
 
-class AwsStuffDoer(App): # type: ignore
+
+class AwsStuffDoer(App):
     """beginnings of aws_stuff_doer terminal ui..."""
 
-    MODES = { # type: ignore
+    MODES = {  # type: ignore
         "default": "main",
         "help": "help",
     }
@@ -16,21 +17,18 @@ class AwsStuffDoer(App): # type: ignore
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("d", "toggle_dark", "Toggle dark mode"),
-        ("m", "switch_mode('default')", "Main"),
-        ("h", "switch_mode('help')", "Help"),
+        ("?", "toggle_help", "Toggle Help"),
     ]
 
-    def action_toggle_dark(self) -> None:
-        """An action to toggle dark mode."""
-        if hasattr(self, "dark"):
-            self.dark = not self.dark
-            self.refresh()
-        else:
-            self.dark = True
-            self.refresh()
+    def action_toggle_help(self) -> None:
+        """An action to toggle the help screen."""
+        current_mode = self.current_mode
+        new_mode = "help" if current_mode != "help" else "default"
+        self.switch_mode(new_mode)
 
     def on_mount(self) -> None:
         self.switch_mode("default")
+
 
 if __name__ == "__main__":
     app = AwsStuffDoer()


### PR DESCRIPTION
This PR puts the help menu and main screen into their own modes. This way we can switch between the screens quickly and they can each have their own stack to push to/pop off of.

I also reorganized the uilib folder structure a bit to make things a little more separated out.. 