### PR TITLE
bunping version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-stuff-doer"
-version = "0.2.2"
+version = "0.2.3"
 description = "ASD is a utility to help manage your AWS projects and sso sessions."
 authors = [
     "Aaron West <aphexlog@gmail.com>",


### PR DESCRIPTION
Adding support for `service` base command to output available aws service names so that you know wat to call in the cli & also added functionality to call service name with --open flag so that you open direct to service.